### PR TITLE
fix: for code scanning alert no. 3: Use of a weak cryptographic key

### DIFF
--- a/legacy-component-cli/ociclient/test/envtest/cert.go
+++ b/legacy-component-cli/ociclient/test/envtest/cert.go
@@ -87,7 +87,7 @@ func GenerateCertificates() (*Certificate, error) {
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		KeyUsage:     x509.KeyUsageDigitalSignature,
 	}
-	certPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	certPrivKey, err := rsa.GenerateKey(rand.Reader, 2048) // only for testing
 	if err != nil {
 		return nil, fmt.Errorf("unable to generate private key: %w", err)
 	}

--- a/pkg/landscaper/jsonschema/testreg/cert.go
+++ b/pkg/landscaper/jsonschema/testreg/cert.go
@@ -87,7 +87,7 @@ func GenerateCertificates() (*Certificate, error) {
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		KeyUsage:     x509.KeyUsageDigitalSignature,
 	}
-	certPrivKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	certPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, fmt.Errorf("unable to generate private key: %w", err)
 	}

--- a/pkg/landscaper/jsonschema/testreg/cert.go
+++ b/pkg/landscaper/jsonschema/testreg/cert.go
@@ -46,7 +46,7 @@ func GenerateCertificates() (*Certificate, error) {
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		BasicConstraintsValid: true,
 	}
-	caPrivKey, err := rsa.GenerateKey(rand.Reader, 1024) // only for testing
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, 2048) // only for testing
 	if err != nil {
 		return nil, fmt.Errorf("unable to generate private key: %w", err)
 	}
@@ -87,7 +87,7 @@ func GenerateCertificates() (*Certificate, error) {
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		KeyUsage:     x509.KeyUsageDigitalSignature,
 	}
-	certPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	certPrivKey, err := rsa.GenerateKey(rand.Reader, 2048) // only for testing
 	if err != nil {
 		return nil, fmt.Errorf("unable to generate private key: %w", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Potential fix for [https://github.com/openmcp-project/landscaper/security/code-scanning/3](https://github.com/openmcp-project/landscaper/security/code-scanning/3)

Use a stronger RSA key size when generating the certificate private key.

Best fix: in `pkg/landscaper/jsonschema/testreg/cert.go`, replace the hardcoded `1024` bit size in the `rsa.GenerateKey` call for `certPrivKey` with `2048`. This preserves existing functionality (RSA key generation and certificate creation flow) while meeting minimum recommended strength and satisfying CodeQL.

No new methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
```

