### PR TITLE
fix: dependency cycle detection

### DIFF
--- a/apis/core/validation/blueprint.go
+++ b/apis/core/validation/blueprint.go
@@ -50,12 +50,12 @@ func ValidateBlueprintWithInstallationTemplates(blueprint *core.Blueprint, insta
 
 // ValidateBlueprintImportDefinitions validates a list of import definitions
 func ValidateBlueprintImportDefinitions(fldPath *field.Path, imports []core.ImportDefinition) field.ErrorList {
-	_, allErrs := validateBlueprintImportDefinitions(fldPath, imports, sets.NewString())
+	_, allErrs := validateBlueprintImportDefinitions(fldPath, imports, sets.New[string]())
 	return allErrs
 }
 
 // validateBlueprintImportDefinitions validates a list of import definitions
-func validateBlueprintImportDefinitions(fldPath *field.Path, imports []core.ImportDefinition, importNames sets.String) (sets.String, field.ErrorList) { //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
+func validateBlueprintImportDefinitions(fldPath *field.Path, imports []core.ImportDefinition, importNames sets.Set[string]) (sets.Set[string], field.ErrorList) {
 	allErrs := field.ErrorList{}
 
 	for i, importDef := range imports {
@@ -109,7 +109,7 @@ func validateBlueprintImportDefinitions(fldPath *field.Path, imports []core.Impo
 func ValidateBlueprintExportDefinitions(fldPath *field.Path, exports []core.ExportDefinition) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	exportNames := sets.NewString()
+	exportNames := sets.New[string]()
 	for i, exportDef := range exports {
 		defPath := fldPath.Index(i)
 		if len(exportDef.Name) != 0 {
@@ -208,7 +208,7 @@ func ValidateJsonSchema(fldPath *field.Path, schema *core.JSONSchemaDefinition) 
 // ValidateTemplateExecutorList validates a list of template executors
 func ValidateTemplateExecutorList(fldPath *field.Path, list []core.TemplateExecutor) field.ErrorList {
 	allErrs := field.ErrorList{}
-	names := sets.NewString()
+	names := sets.New[string]()
 	for i, exec := range list {
 		execPath := fldPath.Index(i)
 		if len(exec.Name) == 0 {
@@ -254,16 +254,16 @@ func ValidateSubinstallations(fldPath *field.Path, subinstallations []core.Subin
 func ValidateInstallationTemplates(fldPath *field.Path, blueprintImportDefs []core.ImportDefinition, subinstallations []*core.InstallationTemplate) field.ErrorList {
 	var (
 		allErrs             = field.ErrorList{}
-		names               = sets.NewString()
+		names               = sets.New[string]()
 		importedDataObjects = make([]Import, 0)
 		exportedDataObjects = map[string]string{}
 		importedTargets     = make([]Import, 0)
 		exportedTargets     = map[string]string{}
 
-		blueprintDataImports       = sets.NewString()
-		blueprintTargetImports     = sets.NewString()
-		blueprintTargetListImports = sets.NewString()
-		blueprintTargetMapImports  = sets.NewString()
+		blueprintDataImports       = sets.New[string]()
+		blueprintTargetImports     = sets.New[string]()
+		blueprintTargetListImports = sets.New[string]()
+		blueprintTargetMapImports  = sets.New[string]()
 	)
 
 	for _, bImport := range blueprintImportDefs {
@@ -387,8 +387,8 @@ func ValidateInstallationTemplates(fldPath *field.Path, blueprintImportDefs []co
 	}
 
 	// validate that all imported values are either satisfied by the blueprint or by another sibling
-	allErrs = append(allErrs, ValidateSatisfiedImports(blueprintDataImports, nil, nil, sets.StringKeySet(exportedDataObjects), importedDataObjects)...)
-	allErrs = append(allErrs, ValidateSatisfiedImports(blueprintTargetImports, blueprintTargetListImports, blueprintTargetMapImports, sets.StringKeySet(exportedTargets), importedTargets)...)
+	allErrs = append(allErrs, ValidateSatisfiedImports(blueprintDataImports, nil, nil, sets.KeySet(exportedDataObjects), importedDataObjects)...)
+	allErrs = append(allErrs, ValidateSatisfiedImports(blueprintTargetImports, blueprintTargetListImports, blueprintTargetMapImports, sets.KeySet(exportedTargets), importedTargets)...)
 
 	return allErrs
 }
@@ -402,7 +402,7 @@ type Import struct {
 }
 
 // ValidateSatisfiedImports validates that all imports are satisfied.
-func ValidateSatisfiedImports(blueprintImports, blueprintListImports, blueprintMapImports, exports sets.String, imports []Import) field.ErrorList { //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
+func ValidateSatisfiedImports(blueprintImports, blueprintListImports, blueprintMapImports, exports sets.Set[string], imports []Import) field.ErrorList {
 	allErrs := field.ErrorList{}
 	for _, imp := range imports {
 		if len(blueprintListImports) > 0 || len(blueprintMapImports) > 0 { // no need to check for references to elements from targetlist/map imports, if there aren't any targetlist/map imports
@@ -465,7 +465,7 @@ func ValidateInstallationTemplate(fldPath *field.Path, template *core.Installati
 // ValidateInstallationTemplateImports validates the imports of an InstallationTemplate
 func ValidateInstallationTemplateImports(imports core.InstallationImports, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	importNames := sets.NewString()
+	importNames := sets.New[string]()
 	var tmpErrs field.ErrorList
 
 	tmpErrs, importNames = ValidateInstallationTemplateDataImports(imports.Data, fldPath.Child("data"), importNames)
@@ -477,7 +477,7 @@ func ValidateInstallationTemplateImports(imports core.InstallationImports, fldPa
 }
 
 // ValidateInstallationTemplateDataImports validates the data imports of an InstallationTemplate
-func ValidateInstallationTemplateDataImports(imports []core.DataImport, fldPath *field.Path, importNames sets.String) (field.ErrorList, sets.String) { //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
+func ValidateInstallationTemplateDataImports(imports []core.DataImport, fldPath *field.Path, importNames sets.Set[string]) (field.ErrorList, sets.Set[string]) {
 	allErrs := field.ErrorList{}
 
 	for idx, imp := range imports {

--- a/apis/core/validation/execution.go
+++ b/apis/core/validation/execution.go
@@ -29,7 +29,7 @@ func ValidateExecutionSpec(fldpath *field.Path, spec core.ExecutionSpec) field.E
 // ValidateDeployItemTemplateList validates a list of deploy item templates.
 func ValidateDeployItemTemplateList(fldPath *field.Path, list core.DeployItemTemplateList) field.ErrorList {
 	allErrs := field.ErrorList{}
-	names := sets.NewString()
+	names := sets.New[string]()
 	hasDuplicates := false
 	for i, tmpl := range list {
 		tmplPath := fldPath.Index(i)
@@ -45,7 +45,7 @@ func ValidateDeployItemTemplateList(fldPath *field.Path, list core.DeployItemTem
 	}
 
 	if !hasDuplicates { // cycle check identifies items by name and the behaviour is undefined if duplicate items are present
-		done := sets.NewString()
+		done := sets.New[string]()
 		cycles := []Cycle{}
 		undefined := []UndefinedDeployItemReference{}
 		for i := range list {
@@ -75,7 +75,7 @@ func ValidateDeployItemTemplateList(fldPath *field.Path, list core.DeployItemTem
 // 1. a list of Cycle objects, representing found cyclic dependencies
 // 2. a list of UndefinedDeployItemReference objects, representing found dependencies to undefined deploy items
 // 3. a set of all deploy item templates (referenced by name) that have already been checked (necessary to avoid finding the same cycle multiple times)
-func getCyclesAndUndefinedDependencies(list core.DeployItemTemplateList, index int, visited visitedList, done sets.String) ([]Cycle, []UndefinedDeployItemReference, sets.String) { //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
+func getCyclesAndUndefinedDependencies(list core.DeployItemTemplateList, index int, visited visitedList, done sets.Set[string]) ([]Cycle, []UndefinedDeployItemReference, sets.Set[string]) {
 	current := list[index]
 	cycles := []Cycle{}
 	undefined := []UndefinedDeployItemReference{}

--- a/apis/core/validation/installation.go
+++ b/apis/core/validation/installation.go
@@ -132,7 +132,7 @@ func ValidateInstallationSucceededReconcile(succeededReconcile *core.SucceededRe
 // ValidateInstallationImports validates the imports of an Installation
 func ValidateInstallationImports(imports core.InstallationImports, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	importNames := sets.NewString()
+	importNames := sets.New[string]()
 	var tmpErrs field.ErrorList
 
 	tmpErrs, importNames = ValidateInstallationDataImports(imports.Data, fldPath.Child("data"), importNames)
@@ -144,7 +144,7 @@ func ValidateInstallationImports(imports core.InstallationImports, fldPath *fiel
 }
 
 // ValidateInstallationDataImports validates the data imports of an Installation
-func ValidateInstallationDataImports(imports []core.DataImport, fldPath *field.Path, importNames sets.String) (field.ErrorList, sets.String) { //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
+func ValidateInstallationDataImports(imports []core.DataImport, fldPath *field.Path, importNames sets.Set[string]) (field.ErrorList, sets.Set[string]) {
 	allErrs := field.ErrorList{}
 
 	for idx, imp := range imports {
@@ -174,7 +174,7 @@ func ValidateInstallationDataImports(imports []core.DataImport, fldPath *field.P
 }
 
 // ValidateInstallationTargetImports validates the target imports of an Installation
-func ValidateInstallationTargetImports(imports []core.TargetImport, fldPath *field.Path, importNames sets.String) (field.ErrorList, sets.String) { //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
+func ValidateInstallationTargetImports(imports []core.TargetImport, fldPath *field.Path, importNames sets.Set[string]) (field.ErrorList, sets.Set[string]) {
 	allErrs := field.ErrorList{}
 
 	for idx, imp := range imports {

--- a/apis/deployer/helm/v1alpha1/validation/validation.go
+++ b/apis/deployer/helm/v1alpha1/validation/validation.go
@@ -43,7 +43,7 @@ func ValidateProviderConfiguration(config *helmv1alpha1.ProviderConfiguration) e
 	}
 
 	expPath := field.NewPath("exportsFromManifests")
-	keys := sets.NewString()
+	keys := sets.New[string]()
 	for i, export := range config.ExportsFromManifests {
 		indexFldPath := expPath.Index(i)
 		if len(export.Key) == 0 {

--- a/controller-utils/pkg/crdmanager/crdmanager.go
+++ b/controller-utils/pkg/crdmanager/crdmanager.go
@@ -98,7 +98,7 @@ func (crdmgr *CRDManager) EnsureCRDs(ctx context.Context) error {
 
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
 		aggregatedStatus := true
-		causingCRDs := sets.NewString()
+		causingCRDs := sets.New[string]()
 
 		for _, crd := range crdList {
 			if !aggregatedStatus {
@@ -125,7 +125,7 @@ func (crdmgr *CRDManager) EnsureCRDs(ctx context.Context) error {
 				}
 			}
 		}
-		logger.Debug("Not all CRDs are ready", "unreadyCRDs", causingCRDs.List())
+		logger.Debug("Not all CRDs are ready", "unreadyCRDs", sets.List(causingCRDs))
 		return aggregatedStatus, nil
 	})
 

--- a/controller-utils/pkg/webhook/certificates.go
+++ b/controller-utils/pkg/webhook/certificates.go
@@ -153,7 +153,7 @@ func loadAndUpdateSecret(ctx context.Context, kubeClient client.Client, secret *
 	}
 
 	// update certificates if the dns names have changed
-	if !sets.NewString(serverCert.Certificate.DNSNames...).HasAll(dnsNames...) {
+	if !sets.New(serverCert.Certificate.DNSNames...).HasAll(dnsNames...) {
 		logger.Info("loadAndUpdateSecret: dns names have changed")
 
 		caCert, serverCert, err = generateNewCAAndServerCert(name, dnsNames, *caConfig)
@@ -292,6 +292,6 @@ func writeCertificate(certDir string, cert *certificates.Certificate) error {
 // }
 
 func StringArrayIncludes(list []string, expects ...string) bool {
-	actual := sets.NewString(list...)
+	actual := sets.New(list...)
 	return actual.HasAll(expects...)
 }

--- a/legacy-component-cli/ociclient/client.go
+++ b/legacy-component-cli/ociclient/client.go
@@ -47,7 +47,7 @@ type client struct {
 	allowPlainHttp bool
 	getHostConfig  docker.RegistryHosts
 
-	knownMediaTypes sets.String //nolint:all
+	knownMediaTypes sets.Set[string]
 }
 
 // NewClient creates a new OCI Client.

--- a/legacy-component-cli/ociclient/constants.go
+++ b/legacy-component-cli/ociclient/constants.go
@@ -13,7 +13,7 @@ const MediaTypeTarGzip = "application/tar+gzip"
 const MediaTypeTar = "application/tar"
 
 // DefaultKnownMediaTypes contain also known media types of the oci client
-var DefaultKnownMediaTypes = sets.NewString(
+var DefaultKnownMediaTypes = sets.New(
 	MediaTypeTarGzip,
 	MediaTypeTar,
 )

--- a/legacy-component-cli/ociclient/types.go
+++ b/legacy-component-cli/ociclient/types.go
@@ -141,7 +141,7 @@ type Options struct {
 	Cache cache.Cache
 
 	// CustomMediaTypes defines the custom known media types
-	CustomMediaTypes sets.String //nolint:all
+	CustomMediaTypes sets.Set[string]
 
 	HTTPClient *http.Client
 }
@@ -203,7 +203,7 @@ type WithKnownMediaType string
 
 func (c WithKnownMediaType) ApplyOption(options *Options) {
 	if options.CustomMediaTypes == nil {
-		options.CustomMediaTypes = sets.NewString(string(c))
+		options.CustomMediaTypes = sets.New(string(c))
 		return
 	}
 

--- a/pkg/landscaper/controllers/context/controller.go
+++ b/pkg/landscaper/controllers/context/controller.go
@@ -39,7 +39,7 @@ func NewDefaulterController(lsUncachedClient, lsCachedClient client.Client,
 		scheme:            scheme,
 		eventRecorder:     eventRecorder,
 		config:            config,
-		excludeNamespaces: sets.NewString(config.Default.ExcludedNamespaces...),
+		excludeNamespaces: sets.New(config.Default.ExcludedNamespaces...),
 	}, nil
 }
 
@@ -50,7 +50,7 @@ type defaulterController struct {
 	eventRecorder     events.EventRecorder
 	scheme            *runtime.Scheme
 	config            config.ContextControllerConfig
-	excludeNamespaces sets.String //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
+	excludeNamespaces sets.Set[string]
 }
 
 func (c *defaulterController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {

--- a/pkg/landscaper/installations/executions/template/inputformatter.go
+++ b/pkg/landscaper/installations/executions/template/inputformatter.go
@@ -32,7 +32,7 @@ func init() {
 // The TemplateInputFormatter formats the input parameter of a template in a human-readable format.
 type TemplateInputFormatter struct {
 	prettyPrint   bool
-	sensitiveKeys sets.String //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
+	sensitiveKeys sets.Set[string]
 }
 
 // NewTemplateInputFormatter creates a new template input formatter.
@@ -42,7 +42,7 @@ type TemplateInputFormatter struct {
 func NewTemplateInputFormatter(prettyPrint bool, sensitiveKeys ...string) *TemplateInputFormatter {
 	return &TemplateInputFormatter{
 		prettyPrint:   prettyPrint,
-		sensitiveKeys: sets.NewString(sensitiveKeys...),
+		sensitiveKeys: sets.New(sensitiveKeys...),
 	}
 }
 

--- a/pkg/landscaper/installations/reconcilehelper/reconcilehelper.go
+++ b/pkg/landscaper/installations/reconcilehelper/reconcilehelper.go
@@ -55,8 +55,7 @@ func NewReconcileHelper(ctx context.Context, op *installations.Operation) (*Reco
 
 ///// VALIDATION METHODS /////
 
-//nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
-func (rh *ReconcileHelper) GetPredecessors(ctx context.Context, predecessorNames sets.String) (map[string]*installations.InstallationAndImports, error) {
+func (rh *ReconcileHelper) GetPredecessors(ctx context.Context, predecessorNames sets.Set[string]) (map[string]*installations.InstallationAndImports, error) {
 	logger, _ := logging.FromContextOrNew(ctx, nil)
 	pm := utils.StartPerformanceMeasurement(&logger, "GetPredecessors")
 	defer pm.StopDebug()
@@ -198,8 +197,7 @@ func (rh *ReconcileHelper) fetchImports() error {
 	return nil
 }
 
-//nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
-func (rh *ReconcileHelper) FetchPredecessors(ctx context.Context) (sets.String, error) {
+func (rh *ReconcileHelper) FetchPredecessors(ctx context.Context) (sets.Set[string], error) {
 	logger, _ := logging.FromContextOrNew(ctx, nil)
 	pm := utils.StartPerformanceMeasurement(&logger, "FetchPredecessors")
 	defer pm.StopDebug()

--- a/pkg/landscaper/installations/subinstallations/subinstallations.go
+++ b/pkg/landscaper/installations/subinstallations/subinstallations.go
@@ -227,7 +227,7 @@ func (o *Operation) createOrUpdateSubinstallations(ctx context.Context,
 	}
 
 	if _, err := dependencies.CheckForCyclesAndDuplicateExports(installationTmpl, false); err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	for _, subInstTmpl := range installationTmpl {

--- a/pkg/utils/dependencies/dependencies.go
+++ b/pkg/utils/dependencies/dependencies.go
@@ -15,7 +15,7 @@ import (
 )
 
 func FetchPredecessorsFromInstallation(installation *lsv1alpha1.Installation,
-	otherInstallations []*lsv1alpha1.Installation) sets.String { //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
+	otherInstallations []*lsv1alpha1.Installation) sets.Set[string] {
 	instNode := newInstallationNodeFromInstallation(installation)
 
 	otherNodes := []*installationNode{}
@@ -34,7 +34,7 @@ func CheckForCyclesAndDuplicateExports(instTemplates []*lsv1alpha1.InstallationT
 		instNodes = append(instNodes, newInstallationNodeFromInstallationTemplate(next))
 	}
 
-	edges := map[string]sets.String{} //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
+	edges := map[string]sets.Set[string]{}
 	for _, next := range instNodes {
 		predecessors, err := next.fetchPredecessors(instNodes)
 		if err != nil {
@@ -94,7 +94,7 @@ func newInstallationNodeFromInstallationTemplate(installation *lsv1alpha1.Instal
 	}
 }
 
-func (r *installationNode) fetchPredecessors(otherNodes []*installationNode) (sets.String, error) { //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
+func (r *installationNode) fetchPredecessors(otherNodes []*installationNode) (sets.Set[string], error) {
 	dataExports, targetExports, hasDuplicateExports := r.getExportMaps(otherNodes)
 
 	if hasDuplicateExports {
@@ -107,7 +107,7 @@ func (r *installationNode) fetchPredecessors(otherNodes []*installationNode) (se
 					dupExpFound = true
 					msg.WriteString("\n  data exports:")
 				}
-				fmt.Fprintf(&msg, "\n    '%s' is exported by [%s]", exp, strings.Join(sources.List(), ", "))
+				fmt.Fprintf(&msg, "\n    '%s' is exported by [%s]", exp, strings.Join(sets.List(sources), ", "))
 			}
 		}
 		dupExpFound = false
@@ -117,13 +117,13 @@ func (r *installationNode) fetchPredecessors(otherNodes []*installationNode) (se
 					dupExpFound = true
 					msg.WriteString("\n  target exports:")
 				}
-				fmt.Fprintf(&msg, "\n    '%s' is exported by [%s]", exp, strings.Join(sources.List(), ", "))
+				fmt.Fprintf(&msg, "\n    '%s' is exported by [%s]", exp, strings.Join(sets.List(sources), ", "))
 			}
 		}
 		return nil, errors.New(msg.String())
 	}
 
-	predecessors := sets.NewString()
+	predecessors := sets.New[string]()
 	for _, imp := range r.imports.Data {
 		if len(imp.DataRef) == 0 {
 			// only dataRef imports can refer to sibling exports
@@ -170,9 +170,9 @@ func (r *installationNode) fetchPredecessors(otherNodes []*installationNode) (se
 // getExportMaps returns a mapping from sibling export names to the exporting siblings' names.
 // If for any given key the length of its value (a set) is greater than 1, this means that two or more siblings define the same export.
 // The third returned parameter indicates whether this has happened or not (true in case of duplicate exports).
-func (r *installationNode) getExportMaps(otherNodes []*installationNode) (map[string]sets.String, map[string]sets.String, bool) { //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
-	dataExports := map[string]sets.String{}   //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
-	targetExports := map[string]sets.String{} //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
+func (r *installationNode) getExportMaps(otherNodes []*installationNode) (map[string]sets.Set[string], map[string]sets.Set[string], bool) {
+	dataExports := map[string]sets.Set[string]{}
+	targetExports := map[string]sets.Set[string]{}
 	hasDuplicateExports := false
 
 	for _, sibling := range otherNodes {
@@ -181,11 +181,11 @@ func (r *installationNode) getExportMaps(otherNodes []*installationNode) (map[st
 			continue
 		}
 		for _, exp := range sibling.exports.Data {
-			var de sets.String //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
+			var de sets.Set[string]
 			var ok bool
 			de, ok = dataExports[exp.DataRef]
 			if !ok {
-				de = sets.NewString()
+				de = sets.New[string]()
 			}
 			de.Insert(sibling.name)
 			if !hasDuplicateExports && de.Len() > 1 {
@@ -194,11 +194,11 @@ func (r *installationNode) getExportMaps(otherNodes []*installationNode) (map[st
 			dataExports[exp.DataRef] = de
 		}
 		for _, exp := range sibling.exports.Targets {
-			var te sets.String //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
+			var te sets.Set[string]
 			var ok bool
 			te, ok = targetExports[exp.Target]
 			if !ok {
-				te = sets.NewString()
+				te = sets.New[string]()
 			}
 			te.Insert(sibling.name)
 			if !hasDuplicateExports && te.Len() > 1 {

--- a/pkg/utils/dependencies/graph.go
+++ b/pkg/utils/dependencies/graph.go
@@ -64,7 +64,9 @@ func (g *graph) breadthFirstSearchForCycles(todo queue.Queue[nodeWithPath]) []st
 		cur, _ := todo.Pop()
 		successors := g.edges[cur.node]
 		for _, succ := range successors.List() {
-			newPath := append(cur.path, succ)
+			newPath := make([]string, len(cur.path)+1)
+			copy(newPath, cur.path)
+			newPath[len(cur.path)] = succ
 			if cur.hasVisitedBefore(succ) {
 				return newPath
 			}

--- a/pkg/utils/dependencies/graph.go
+++ b/pkg/utils/dependencies/graph.go
@@ -13,11 +13,11 @@ import (
 )
 
 type graph struct {
-	edges map[string]sets.String //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
+	edges map[string]sets.Set[string]
 
 	// alreadyCheckedElements contains elements of which it is already known that they cannot reach a cycle.
 	// The set is initially empty and grows during the algorithm.
-	alreadyCheckedElements sets.String //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
+	alreadyCheckedElements sets.Set[string]
 }
 
 // nodeWithPath stores a node of a graph as well as the path that led to this node.
@@ -36,10 +36,10 @@ func (nwp nodeWithPath) hasVisitedBefore(elem string) bool {
 	return false
 }
 
-func newGraph(edges map[string]sets.String) *graph { //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
+func newGraph(edges map[string]sets.Set[string]) *graph {
 	return &graph{
 		edges:                  edges,
-		alreadyCheckedElements: sets.NewString(),
+		alreadyCheckedElements: sets.New[string](),
 	}
 }
 
@@ -63,7 +63,7 @@ func (g *graph) breadthFirstSearchForCycles(todo queue.Queue[nodeWithPath]) []st
 	for !todo.IsEmpty() {
 		cur, _ := todo.Pop()
 		successors := g.edges[cur.node]
-		for _, succ := range successors.List() {
+		for _, succ := range sets.List(successors) {
 			newPath := make([]string, len(cur.path)+1)
 			copy(newPath, cur.path)
 			newPath[len(cur.path)] = succ
@@ -114,7 +114,7 @@ func (g *graph) getReverseOrder() ([]string, error) {
 
 func (g *graph) allSuccessorAlreadyAdded(node string, alreadyAddedNodes map[string]bool) bool {
 	succs := g.edges[node]
-	for _, nextSucc := range succs.List() {
+	for _, nextSucc := range sets.List(succs) {
 		if _, ok := alreadyAddedNodes[nextSucc]; !ok {
 			return false
 		}

--- a/pkg/utils/dependencies/graph_test.go
+++ b/pkg/utils/dependencies/graph_test.go
@@ -21,13 +21,13 @@ var _ = Describe("Cyclic Dependency Determination Tests", func() {
 	Context("DetermineCyclicDependencies", func() {
 
 		It("should not detect cyclic dependencies if there aren't any", func() {
-			deps := map[string]sets.String{ //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
-				"a": sets.NewString().Insert("b", "c", "f"),
-				"b": sets.NewString().Insert("c", "f"),
-				"c": sets.NewString().Insert("d", "f"),
-				"d": sets.NewString().Insert("f"),
-				"e": sets.NewString().Insert("f"),
-				"f": sets.NewString().Insert(),
+			deps := map[string]sets.Set[string]{
+				"a": sets.New("b", "c", "f"),
+				"b": sets.New("c", "f"),
+				"c": sets.New("d", "f"),
+				"d": sets.New("f"),
+				"e": sets.New("f"),
+				"f": sets.New[string](),
 			}
 
 			hasCycle, cycle := newGraph(deps).hasCycle()
@@ -36,10 +36,10 @@ var _ = Describe("Cyclic Dependency Determination Tests", func() {
 		})
 
 		It("should not detect cyclic dependencies if there aren't any", func() {
-			deps := map[string]sets.String{ //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
-				"c": sets.NewString().Insert("b"),
-				"b": sets.NewString().Insert("a"),
-				"a": sets.NewString(),
+			deps := map[string]sets.Set[string]{
+				"c": sets.New("b"),
+				"b": sets.New("a"),
+				"a": sets.New[string](),
 			}
 
 			hasCycle, cycle := newGraph(deps).hasCycle()
@@ -48,10 +48,10 @@ var _ = Describe("Cyclic Dependency Determination Tests", func() {
 		})
 
 		It("should detect simple cyclic dependencies", func() {
-			deps := map[string]sets.String{ //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
-				"c": sets.NewString().Insert("b"),
-				"b": sets.NewString().Insert("a"),
-				"a": sets.NewString().Insert("c"),
+			deps := map[string]sets.Set[string]{
+				"c": sets.New("b"),
+				"b": sets.New("a"),
+				"a": sets.New("c"),
 			}
 
 			hasCycle, cycle := newGraph(deps).hasCycle()
@@ -60,8 +60,8 @@ var _ = Describe("Cyclic Dependency Determination Tests", func() {
 		})
 
 		It("should detect one-elemented cyclic dependencies", func() {
-			deps := map[string]sets.String{ //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
-				"a": sets.NewString().Insert("a"),
+			deps := map[string]sets.Set[string]{
+				"a": sets.New("a"),
 			}
 
 			hasCycle, cycle := newGraph(deps).hasCycle()
@@ -70,11 +70,11 @@ var _ = Describe("Cyclic Dependency Determination Tests", func() {
 		})
 
 		It("should detect multiple independent cycles", func() {
-			deps := map[string]sets.String{ //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
-				"d": sets.NewString().Insert("c"),
-				"c": sets.NewString().Insert("d"),
-				"b": sets.NewString().Insert("a"),
-				"a": sets.NewString().Insert("b"),
+			deps := map[string]sets.Set[string]{
+				"d": sets.New("c"),
+				"c": sets.New("d"),
+				"b": sets.New("a"),
+				"a": sets.New("b"),
 			}
 
 			hasCycle, cycle := newGraph(deps).hasCycle()
@@ -83,11 +83,11 @@ var _ = Describe("Cyclic Dependency Determination Tests", func() {
 		})
 
 		It("should detect multiple connected cycles", func() {
-			deps := map[string]sets.String{ //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
-				"b": sets.NewString().Insert("a"),
-				"a": sets.NewString().Insert("d"),
-				"d": sets.NewString().Insert("c"),
-				"c": sets.NewString().Insert("d", "b"),
+			deps := map[string]sets.Set[string]{
+				"b": sets.New("a"),
+				"a": sets.New("d"),
+				"d": sets.New("c"),
+				"c": sets.New("d", "b"),
 			}
 
 			hasCycle, cycle := newGraph(deps).hasCycle()
@@ -97,17 +97,17 @@ var _ = Describe("Cyclic Dependency Determination Tests", func() {
 		})
 
 		It("should order the graph correctly according to its edges", func() {
-			deps := map[string]sets.String{ //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
-				"a": sets.NewString().Insert("c"),
-				"b": sets.NewString().Insert("f", "e"),
-				"c": sets.NewString().Insert("d", "e"),
-				"d": sets.NewString().Insert("i"),
-				"e": sets.NewString().Insert("h"),
-				"f": sets.NewString().Insert("e", "g"),
-				"g": sets.NewString().Insert("h"),
-				"h": sets.NewString().Insert("i", "j"),
-				"i": sets.NewString(),
-				"j": sets.NewString(),
+			deps := map[string]sets.Set[string]{
+				"a": sets.New("c"),
+				"b": sets.New("f", "e"),
+				"c": sets.New("d", "e"),
+				"d": sets.New("i"),
+				"e": sets.New("h"),
+				"f": sets.New("e", "g"),
+				"g": sets.New("h"),
+				"h": sets.New("i", "j"),
+				"i": sets.New[string](),
+				"j": sets.New[string](),
 			}
 
 			g := newGraph(deps)

--- a/pkg/utils/dependencies/graph_test.go
+++ b/pkg/utils/dependencies/graph_test.go
@@ -22,6 +22,21 @@ var _ = Describe("Cyclic Dependency Determination Tests", func() {
 
 		It("should not detect cyclic dependencies if there aren't any", func() {
 			deps := map[string]sets.String{ //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
+				"a": sets.NewString().Insert("b", "c", "f"),
+				"b": sets.NewString().Insert("c", "f"),
+				"c": sets.NewString().Insert("d", "f"),
+				"d": sets.NewString().Insert("f"),
+				"e": sets.NewString().Insert("f"),
+				"f": sets.NewString().Insert(),
+			}
+
+			hasCycle, cycle := newGraph(deps).hasCycle()
+			Expect(hasCycle).To(BeFalse())
+			Expect(cycle).To(BeEmpty())
+		})
+
+		It("should not detect cyclic dependencies if there aren't any", func() {
+			deps := map[string]sets.String{ //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
 				"c": sets.NewString().Insert("b"),
 				"b": sets.NewString().Insert("a"),
 				"a": sets.NewString(),

--- a/test/framework/dump.go
+++ b/test/framework/dump.go
@@ -33,7 +33,7 @@ import (
 type Dumper struct {
 	kubeClient    client.Client
 	kubeClientSet kubernetes.Interface
-	namespaces    sets.String //nolint:staticcheck // Ignore SA1019 // TODO: change to generic set
+	namespaces    sets.Set[string]
 	lsNamespace   string
 	logger        utils.Logger
 	startTime     time.Time
@@ -46,7 +46,7 @@ func NewDumper(logger utils.Logger, kubeClient client.Client, kubeClientSet kube
 		logger:        logger,
 		kubeClient:    kubeClient,
 		kubeClientSet: kubeClientSet,
-		namespaces:    sets.NewString(namespaces...),
+		namespaces:    sets.New(namespaces...),
 		lsNamespace:   lsNamespace,
 	}
 }
@@ -58,7 +58,7 @@ func (d *Dumper) AddNamespaces(namespaces ...string) {
 
 // ClearNamespaces removes all current namespaces
 func (d *Dumper) ClearNamespaces() {
-	d.namespaces = sets.NewString()
+	d.namespaces = sets.New[string]()
 }
 
 // Dump searches for known objects in the given namespaces and dumps useful information about their state.


### PR DESCRIPTION
**What this PR does / why we need it**:

1. The installation controller checks whether the dependency graph of subinstallations contains a cycle. In some cases, the check could report a cycle even if there was none. The bug was caused by Go's slice aliasing with append (see the fix in method `breadthFirstSearchForCycles` by copying the slice).

2. An installation succeeded even if the check for cyclic dependencies failed. This is fixed.

3. The deprecated `sets.String` is replaced by `sets.Set[string]`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
- Bugfix concerning the detection of dependency cycles between subinstallations.
- Bugfix concerning the error handling of dependency cycles between subinstallations.
```
