### PR TITLE
chore: update Apache-2.0 license copyright placeholder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 OpenControlPlane contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 OpenControlPlane contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## What

Replace the Apache-2.0 license copyright placeholder with the correct project copyright.

- `LICENSE`: `Copyright [yyyy] [name of copyright owner]` → `Copyright 2026 OpenControlPlane contributors`
- `LICENSES/Apache-2.0.txt`: same replacement

## Why

Per [NeoNephos Project Guidelines](https://github.com/neonephos/guidelines-development/blob/main/project-guidelines/project-guidelines.md). Part of https://github.com/openmcp-project/backlog/issues/533.